### PR TITLE
Fix license_detector import for package layout

### DIFF
--- a/menace/code_database.py
+++ b/menace/code_database.py
@@ -28,7 +28,10 @@ import sys
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 from dataclasses import asdict
 
-import license_detector
+try:  # pragma: no cover - support package-relative import
+    from . import license_detector  # type: ignore
+except Exception:  # pragma: no cover - fallback for flat layout
+    import license_detector  # type: ignore
 try:  # pragma: no cover - allow running without vector_service
     from vector_service import EmbeddableDBMixin, EmbeddingBackfill
 except Exception:  # pragma: no cover - lightweight stub for tests


### PR DESCRIPTION
## Summary
- update `menace.code_database` to import the bundled `license_detector` module when running as a package
- retain compatibility with flat layouts by falling back to the original absolute import

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cbb2729144832e8fd98d78c661025a