### PR TITLE
Fix context builder import loop and add prompt failure utilities

### DIFF
--- a/chunk_summary_cache.py
+++ b/chunk_summary_cache.py
@@ -1,0 +1,64 @@
+"""Filesystem backed cache for storing chunk summary metadata."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, Iterable
+import hashlib
+
+logger = logging.getLogger(__name__)
+
+
+class ChunkSummaryCache:
+    """Persist chunk summaries keyed by path hashes on disk."""
+
+    def __init__(self, directory: str | Path) -> None:
+        self.directory = Path(directory)
+        self.directory.mkdir(parents=True, exist_ok=True)
+
+    def _file_for(self, key: str) -> Path:
+        safe_key = key.strip().replace("/", "_").replace("\\", "_")
+        return self.directory / f"{safe_key}.json"
+
+    def hash_path(self, path: Path) -> str:
+        return hashlib.sha256(str(path).encode("utf-8")).hexdigest()
+
+    def get(self, key: str) -> Dict[str, Any] | None:
+        path = self._file_for(key)
+        try:
+            with path.open("r", encoding="utf-8") as fh:
+                return json.load(fh)
+        except FileNotFoundError:
+            return None
+        except Exception:
+            logger.debug("failed to read chunk summary cache for key %s", key, exc_info=True)
+            return None
+
+    def set(self, key: str, summaries: Iterable[Dict[str, Any]]) -> None:
+        path = self._file_for(key)
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        data = {"summaries": list(summaries)}
+        try:
+            with tmp_path.open("w", encoding="utf-8") as fh:
+                json.dump(data, fh)
+            tmp_path.replace(path)
+        except Exception:
+            logger.debug("failed to write chunk summary cache for key %s", key, exc_info=True)
+            try:
+                if tmp_path.exists():
+                    tmp_path.unlink()
+            except Exception:
+                logger.debug("failed to cleanup temporary cache file for key %s", key, exc_info=True)
+
+    def clear(self) -> None:
+        try:
+            for item in self.directory.iterdir():
+                if item.is_file():
+                    try:
+                        item.unlink()
+                    except FileNotFoundError:
+                        continue
+        except Exception:
+            logger.debug("failed to clear chunk summary cache", exc_info=True)

--- a/chunking.py
+++ b/chunking.py
@@ -6,7 +6,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, TYPE_CHECKING
 
-from context_builder import handle_failure, PromptBuildError
+try:  # pragma: no cover - support both package and flat layouts
+    from menace.prompt_failure import handle_failure, PromptBuildError
+except Exception:  # pragma: no cover - fallback when running from source root
+    from prompt_failure import handle_failure, PromptBuildError  # type: ignore
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
     from llm_interface import LLMClient
@@ -288,7 +291,11 @@ def summarize_snippet(
         except Exception as exc:
             if isinstance(exc, PromptBuildError):
                 raise
-            handle_failure("failed to build snippet summary prompt", exc)
+            handle_failure(
+                "failed to build snippet summary prompt",
+                exc,
+                raise_error=False,
+            )
         else:
             try:
                 result = llm.generate(prompt, context_builder=context_builder)

--- a/menace/context_builder.py
+++ b/menace/context_builder.py
@@ -22,7 +22,10 @@ from filelock import FileLock
 
 from redaction_utils import redact_text
 from snippet_compressor import compress_snippets
-from context_builder import handle_failure, PromptBuildError
+try:  # pragma: no cover - prefer package relative import when available
+    from .prompt_failure import handle_failure, PromptBuildError
+except Exception:  # pragma: no cover - fallback for execution from source root
+    from prompt_failure import handle_failure, PromptBuildError  # type: ignore
 
 from .decorators import log_and_measure
 from .exceptions import MalformedPromptError, RateLimitError, VectorServiceError

--- a/menace/sandbox_runner.py
+++ b/menace/sandbox_runner.py
@@ -45,7 +45,10 @@ from vector_service import FallbackResult, ContextBuilder
 from prompt_types import Prompt
 from snippet_compressor import compress_snippets
 from context_builder_util import ensure_fresh_weights
-from context_builder import handle_failure, PromptBuildError
+try:  # pragma: no cover - allow execution inside the package and flat layout
+    from .prompt_failure import handle_failure, PromptBuildError
+except Exception:  # pragma: no cover - fallback when executed from source root
+    from prompt_failure import handle_failure, PromptBuildError  # type: ignore
 try:  # pragma: no cover - optional dependency
     from vector_service import ErrorResult  # type: ignore
 except Exception:  # pragma: no cover - fallback
@@ -679,6 +682,7 @@ def build_section_prompt(
             "failed to build sandbox section prompt",
             exc,
             logger=logger,
+            raise_error=False,
         )
         raise
 

--- a/menace/self_coding_engine.py
+++ b/menace/self_coding_engine.py
@@ -23,24 +23,31 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import contextvars
 
 try:  # pragma: no cover - prefer package-relative import when available
-    from .context_builder import handle_failure, PromptBuildError
+    from .prompt_failure import handle_failure, PromptBuildError
 except Exception:  # pragma: no cover - fall back to flat layout or stubs
     try:
-        from context_builder import handle_failure, PromptBuildError  # type: ignore
+        from prompt_failure import handle_failure, PromptBuildError  # type: ignore
     except Exception:  # pragma: no cover - minimal graceful degradation
 
         class PromptBuildError(RuntimeError):
-            """Fallback error used when the real context builder is unavailable."""
+            """Fallback error used when the shared failure helpers are unavailable."""
 
-        def handle_failure(message: str, exc: Exception, *, logger=None) -> None:
-            """Fallback failure handler that logs and re-raises the exception."""
+        def handle_failure(
+            message: str,
+            exc: Exception,
+            *,
+            logger=None,
+            raise_error: bool = True,
+        ) -> None:
+            """Fallback failure handler that logs and optionally re-raises."""
 
             if logger is not None:
                 try:
                     logger.exception(message, exc_info=exc)
                 except Exception:
                     pass
-            raise exc
+            if raise_error:
+                raise exc
 
 from .code_database import CodeDB, CodeRecord, PatchHistoryDB, PatchRecord
 from .unified_event_bus import UnifiedEventBus

--- a/prompt_failure.py
+++ b/prompt_failure.py
@@ -1,0 +1,55 @@
+"""Utilities for reporting prompt construction failures consistently."""
+
+from __future__ import annotations
+
+import logging
+
+
+class PromptBuildError(RuntimeError):
+    """Exception raised when a prompt cannot be constructed reliably."""
+
+    def __init__(self, message: str, *, cause: Exception | None = None) -> None:
+        super().__init__(message)
+        self.cause = cause
+
+
+def handle_failure(
+    message: str,
+    exc: Exception,
+    *,
+    logger: logging.Logger | None = None,
+    raise_error: bool = True,
+) -> None:
+    """Log ``exc`` against ``message`` and optionally raise a wrapped error.
+
+    Parameters
+    ----------
+    message:
+        Human readable context describing the failure.
+    exc:
+        The original exception that triggered the failure handling.
+    logger:
+        Optional logger used for reporting.  When ``None`` a module level logger
+        is used instead.  Any logging errors are swallowed so that failure
+        handling never introduces additional crashes.
+    raise_error:
+        When ``True`` (the default) the function re-raises ``exc`` wrapped in a
+        :class:`PromptBuildError`.  Callers can disable re-raising when they only
+        need to record the failure but intend to handle the error themselves.
+    """
+
+    log = logger or logging.getLogger(__name__)
+    try:
+        log.exception(message, exc_info=exc)
+    except Exception:
+        # ``logger`` might be a mock or custom object.  Avoid bubbling up logging
+        # issues when handling the original failure.
+        logging.getLogger(__name__).error("%s: %s", message, exc)
+
+    if not raise_error:
+        return
+
+    if isinstance(exc, PromptBuildError):
+        raise exc
+
+    raise PromptBuildError(message, cause=exc) from exc


### PR DESCRIPTION
## Summary
- add a standalone `prompt_failure` helper so modules share the same `PromptBuildError` implementation without circular imports
- update chunking, sandbox runner, and the self-coding engine to use the shared helpers and keep logging-only error paths from re-raising
- provide a simple filesystem-backed `ChunkSummaryCache` to satisfy chunking's cache dependency

## Testing
- python manual_bootstrap.py *(fails: ModuleNotFoundError: No module named 'unsafe_patterns')*

------
https://chatgpt.com/codex/tasks/task_e_68cbd774c5f0832ea675022e0fe3664c