### PR TITLE
Handle missing EmbeddingBackfill watcher method

### DIFF
--- a/menace/code_database.py
+++ b/menace/code_database.py
@@ -110,8 +110,13 @@ def _ensure_backfill_watcher(bus: "UnifiedEventBus" | None) -> None:
     if bus is None or _WATCH_THREAD is not None:
         return
     try:
+        backfill = EmbeddingBackfill()
+        watch_events = getattr(backfill, "watch_events", None)
+        if watch_events is None:
+            logger.info("embedding watcher unavailable; skipping startup")
+            return
         thread = threading.Thread(
-            target=EmbeddingBackfill().watch_events,
+            target=watch_events,
             kwargs={"bus": bus},
             daemon=True,
         )


### PR DESCRIPTION
## Summary
- avoid AttributeError when the vector_service EmbeddingBackfill stub lacks a watch_events method
- skip starting the embedding watcher and log a message when watch_events is unavailable

## Testing
- python manual_bootstrap.py

------
https://chatgpt.com/codex/tasks/task_e_68ccc3a1e6a8832eac8e06bdb3c88b28