### PR TITLE
Fix pydantic v1 synergy validators

### DIFF
--- a/menace/sandbox_settings.py
+++ b/menace/sandbox_settings.py
@@ -401,7 +401,11 @@ class SynergySettings(BaseModel):
             "gamma",
         )
         def _synergy_unit_range(
-            cls, v: float | None, values: dict[str, Any], field: Any, **_: Any
+            cls,
+            v: float | None,
+            values: dict[str, Any],
+            config: Any,
+            field: Any,
         ) -> float | None:
             field_name = getattr(field, "name", "value")
             if v is not None and not 0 <= v <= 1:
@@ -421,7 +425,11 @@ class SynergySettings(BaseModel):
             "python_max_replay",
         )
         def _synergy_positive_int(
-            cls, v: int | None, values: dict[str, Any], field: Any, **_: Any
+            cls,
+            v: int | None,
+            values: dict[str, Any],
+            config: Any,
+            field: Any,
         ) -> int | None:
             field_name = getattr(field, "name", "value")
             if v is not None and v <= 0:
@@ -441,7 +449,11 @@ class SynergySettings(BaseModel):
             "deviation_tolerance",
         )
         def _synergy_non_negative(
-            cls, v: float, values: dict[str, Any], field: Any, **_: Any
+            cls,
+            v: float,
+            values: dict[str, Any],
+            config: Any,
+            field: Any,
         ) -> float:
             field_name = getattr(field, "name", "value")
             if v < 0:


### PR DESCRIPTION
## Summary
- update the SynergySettings validators to use the pydantic v1-compatible signature so they accept the config argument without errors

## Testing
- `python manual_bootstrap.py` *(fails: ModuleNotFoundError: No module named 'unsafe_patterns')*

------
https://chatgpt.com/codex/tasks/task_e_68cd1bab3bc8832e9b0d307c5461baa3