### PR TITLE
Fix alignment settings validator signature

### DIFF
--- a/menace/sandbox_settings.py
+++ b/menace/sandbox_settings.py
@@ -487,9 +487,16 @@ class AlignmentSettings(BaseModel):
         "improvement_warning_threshold",
         "improvement_failure_threshold",
     )
-    def _alignment_unit_range(cls, v: float, info: Any) -> float:
+    def _alignment_unit_range(
+        cls,
+        v: float,
+        values: dict[str, Any],
+        config: Any,
+        field: Any,
+    ) -> float:
+        field_name = getattr(field, "name", getattr(field, "field_name", "value"))
         if not 0 <= v <= 1:
-            raise ValueError(f"{info.field_name} must be between 0 and 1")
+            raise ValueError(f"{field_name} must be between 0 and 1")
         return v
 
 


### PR DESCRIPTION
## Summary
- update the alignment threshold validator signature to be compatible with the active Pydantic version
- derive the field name defensively when generating the validation error message

## Testing
- python manual_bootstrap.py

------
https://chatgpt.com/codex/tasks/task_e_68cd1cb9b3c0832e9781661b7b0a43c7