### PR TITLE
Fix SynergySettings validator reuse

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -502,7 +502,7 @@ class SynergySettings(BaseModel):
             raise ValueError(f"{field_name} must be non-negative")
         return v
 
-    @field_validator("strategy")
+    @field_validator("strategy", **FIELD_VALIDATOR_KWARGS)
     def _synergy_strategy(cls, v: str) -> str:
         allowed = {"dqn", "double_dqn", "sac", "td3"}
         if v not in allowed:


### PR DESCRIPTION
## Summary
- allow the SynergySettings strategy validator to be reused so pydantic no longer raises a duplicate validator error during import

## Testing
- python manual_bootstrap.py *(fails: ModuleNotFoundError: No module named 'vector_service.context_builder')*

------
https://chatgpt.com/codex/tasks/task_e_68cd6e91d4d8832e895bfa7599dd7c26