### PR TITLE
Fix AlignmentSettings validator reuse

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -528,6 +528,7 @@ class AlignmentSettings(BaseModel):
         "failure_threshold",
         "improvement_warning_threshold",
         "improvement_failure_threshold",
+        **FIELD_VALIDATOR_KWARGS,
     )
     @_apply_validator_signature
     def _alignment_unit_range(


### PR DESCRIPTION
## Summary
- ensure the AlignmentSettings threshold validator passes along FIELD_VALIDATOR_KWARGS so `allow_reuse` is honoured when available

## Testing
- python manual_bootstrap.py *(fails: ModuleNotFoundError: No module named 'vector_service.context_builder')*

------
https://chatgpt.com/codex/tasks/task_e_68cd70193918832eab2f2bb1b0688daf