### PR TITLE
Handle PolicySettings temperature validator reuse

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -699,7 +699,7 @@ class PolicySettings(BaseModel):
             raise ValueError(f"{field_name} must be between 0 and 1")
         return v
 
-    @field_validator("temperature")
+    @field_validator("temperature", **FIELD_VALIDATOR_KWARGS)
     def _policy_temperature(cls, v: float) -> float:
         if v <= 0:
             raise ValueError("temperature must be positive")


### PR DESCRIPTION
## Summary
- update the PolicySettings temperature validator decorator to pass FIELD_VALIDATOR_KWARGS so it can be reused without triggering pydantic's duplicate validator error

## Testing
- python - <<'PY'
from sandbox_settings import PolicySettings
print(PolicySettings())
PY

------
https://chatgpt.com/codex/tasks/task_e_68cd798f84c4832e80f4fcdebe1ae821