### PR TITLE
Fix duplicate sandbox dependency validators

### DIFF
--- a/menace/sandbox_settings.py
+++ b/menace/sandbox_settings.py
@@ -1146,6 +1146,7 @@ class SandboxSettings(BaseSettings):
             "required_env_vars",
             "sandbox_required_db_files",
             mode="before",
+            **FIELD_VALIDATOR_KWARGS,
         )
         def _parse_dependency_list(cls, v: Any) -> Any:
             if isinstance(v, str):
@@ -1157,7 +1158,11 @@ class SandboxSettings(BaseSettings):
                     return [i.strip() for i in v.split(",") if i.strip()]
             return v
 
-        @field_validator("optional_service_versions", mode="before")
+        @field_validator(
+            "optional_service_versions",
+            mode="before",
+            **FIELD_VALIDATOR_KWARGS,
+        )
         def _parse_optional_service_versions(cls, v: Any) -> Any:
             if isinstance(v, str):
                 try:
@@ -1166,7 +1171,11 @@ class SandboxSettings(BaseSettings):
                     return {}
             return v
 
-        @field_validator("available_backends", mode="before")
+        @field_validator(
+            "available_backends",
+            mode="before",
+            **FIELD_VALIDATOR_KWARGS,
+        )
         def _parse_available_backends(cls, v: Any) -> Any:
             if isinstance(v, str):
                 try:
@@ -1183,6 +1192,7 @@ class SandboxSettings(BaseSettings):
             "required_env_vars",
             "sandbox_required_db_files",
             pre=True,
+            **FIELD_VALIDATOR_KWARGS,
         )
         def _parse_dependency_list(cls, v: Any) -> Any:  # type: ignore[override]
             if isinstance(v, str):
@@ -1194,7 +1204,11 @@ class SandboxSettings(BaseSettings):
                     return [i.strip() for i in v.split(",") if i.strip()]
             return v
 
-        @field_validator("optional_service_versions", pre=True)
+        @field_validator(
+            "optional_service_versions",
+            pre=True,
+            **FIELD_VALIDATOR_KWARGS,
+        )
         def _parse_optional_service_versions(cls, v: Any) -> Any:  # type: ignore[override]
             if isinstance(v, str):
                 try:
@@ -1203,7 +1217,11 @@ class SandboxSettings(BaseSettings):
                     return {}
             return v
 
-        @field_validator("available_backends", pre=True)
+        @field_validator(
+            "available_backends",
+            pre=True,
+            **FIELD_VALIDATOR_KWARGS,
+        )
         def _parse_available_backends(cls, v: Any) -> Any:  # type: ignore[override]
             if isinstance(v, str):
                 try:

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -1092,6 +1092,7 @@ class SandboxSettings(BaseSettings):
             "required_env_vars",
             "sandbox_required_db_files",
             mode="before",
+            **FIELD_VALIDATOR_KWARGS,
         )
         def _parse_dependency_list(cls, v: Any) -> Any:
             if isinstance(v, str):
@@ -1103,7 +1104,11 @@ class SandboxSettings(BaseSettings):
                     return [i.strip() for i in v.split(",") if i.strip()]
             return v
 
-        @field_validator("optional_service_versions", mode="before")
+        @field_validator(
+            "optional_service_versions",
+            mode="before",
+            **FIELD_VALIDATOR_KWARGS,
+        )
         def _parse_optional_service_versions(cls, v: Any) -> Any:
             if isinstance(v, str):
                 try:
@@ -1112,7 +1117,11 @@ class SandboxSettings(BaseSettings):
                     return {}
             return v
 
-        @field_validator("available_backends", mode="before")
+        @field_validator(
+            "available_backends",
+            mode="before",
+            **FIELD_VALIDATOR_KWARGS,
+        )
         def _parse_available_backends(cls, v: Any) -> Any:
             if isinstance(v, str):
                 try:
@@ -1129,6 +1138,7 @@ class SandboxSettings(BaseSettings):
             "required_env_vars",
             "sandbox_required_db_files",
             pre=True,
+            **FIELD_VALIDATOR_KWARGS,
         )
         def _parse_dependency_list(cls, v: Any) -> Any:  # type: ignore[override]
             if isinstance(v, str):
@@ -1140,7 +1150,11 @@ class SandboxSettings(BaseSettings):
                     return [i.strip() for i in v.split(",") if i.strip()]
             return v
 
-        @field_validator("optional_service_versions", pre=True)
+        @field_validator(
+            "optional_service_versions",
+            pre=True,
+            **FIELD_VALIDATOR_KWARGS,
+        )
         def _parse_optional_service_versions(cls, v: Any) -> Any:  # type: ignore[override]
             if isinstance(v, str):
                 try:
@@ -1149,7 +1163,11 @@ class SandboxSettings(BaseSettings):
                     return {}
             return v
 
-        @field_validator("available_backends", pre=True)
+        @field_validator(
+            "available_backends",
+            pre=True,
+            **FIELD_VALIDATOR_KWARGS,
+        )
         def _parse_available_backends(cls, v: Any) -> Any:  # type: ignore[override]
             if isinstance(v, str):
                 try:


### PR DESCRIPTION
## Summary
- add allow_reuse support when parsing dependency lists in both sandbox settings modules to avoid duplicate validator errors

## Testing
- python manual_bootstrap.py *(fails: ModuleNotFoundError: No module named 'vector_service.context_builder')*

------
https://chatgpt.com/codex/tasks/task_e_68cd7eab1090832e97e491c5de3266ad