### PR TITLE
Fix Pydantic validator reuse for Codex settings

### DIFF
--- a/menace/sandbox_settings.py
+++ b/menace/sandbox_settings.py
@@ -1271,7 +1271,7 @@ class SandboxSettings(BaseSettings):
         ),
     )
 
-    @field_validator("codex_fallback_strategy")
+    @field_validator("codex_fallback_strategy", **FIELD_VALIDATOR_KWARGS)
     def _codex_strategy_valid(cls, v: str) -> str:
         if v not in {"queue", "reroute"}:
             raise ValueError("codex_fallback_strategy must be 'queue' or 'reroute'")
@@ -1279,7 +1279,7 @@ class SandboxSettings(BaseSettings):
 
     if PYDANTIC_V2:
 
-        @field_validator("codex_retry_delays", mode="before")
+        @field_validator("codex_retry_delays", mode="before", **FIELD_VALIDATOR_KWARGS)
         def _parse_codex_retry_delays(cls, v: Any) -> Any:
             if isinstance(v, str):
                 try:
@@ -1292,7 +1292,7 @@ class SandboxSettings(BaseSettings):
 
     else:  # pragma: no cover - pydantic<2
 
-        @field_validator("codex_retry_delays", pre=True)
+        @field_validator("codex_retry_delays", pre=True, **FIELD_VALIDATOR_KWARGS)
         def _parse_codex_retry_delays(cls, v: Any) -> Any:  # type: ignore[override]
             if isinstance(v, str):
                 try:

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -1217,7 +1217,7 @@ class SandboxSettings(BaseSettings):
         ),
     )
 
-    @field_validator("codex_fallback_strategy")
+    @field_validator("codex_fallback_strategy", **FIELD_VALIDATOR_KWARGS)
     def _codex_strategy_valid(cls, v: str) -> str:
         if v not in {"queue", "reroute"}:
             raise ValueError("codex_fallback_strategy must be 'queue' or 'reroute'")
@@ -1225,7 +1225,7 @@ class SandboxSettings(BaseSettings):
 
     if PYDANTIC_V2:
 
-        @field_validator("codex_retry_delays", mode="before")
+        @field_validator("codex_retry_delays", mode="before", **FIELD_VALIDATOR_KWARGS)
         def _parse_codex_retry_delays(cls, v: Any) -> Any:
             if isinstance(v, str):
                 try:
@@ -1238,7 +1238,7 @@ class SandboxSettings(BaseSettings):
 
     else:  # pragma: no cover - pydantic<2
 
-        @field_validator("codex_retry_delays", pre=True)
+        @field_validator("codex_retry_delays", pre=True, **FIELD_VALIDATOR_KWARGS)
         def _parse_codex_retry_delays(cls, v: Any) -> Any:  # type: ignore[override]
             if isinstance(v, str):
                 try:


### PR DESCRIPTION
## Summary
- ensure Codex fallback and retry validators opt into FIELD_VALIDATOR_KWARGS in both sandbox settings modules
- avoid duplicate validator registration errors when importing SandboxSettings under pydantic v1 compatibility

## Testing
- python - <<'PY'
from sandbox_settings import SandboxSettings
from menace.sandbox_settings import SandboxSettings as InnerSandboxSettings
PY


------
https://chatgpt.com/codex/tasks/task_e_68cd812cee9c832ebe810b8bb8a4e105