### PR TITLE
Fix ContextBuilder import compatibility

### DIFF
--- a/context_builder.py
+++ b/context_builder.py
@@ -22,22 +22,63 @@ from filelock import FileLock
 
 from redaction_utils import redact_text
 from snippet_compressor import compress_snippets
-from context_builder import handle_failure, PromptBuildError
+try:  # pragma: no cover - prefer package relative import when available
+    from menace.prompt_failure import handle_failure, PromptBuildError  # type: ignore
+except Exception:  # pragma: no cover - fallback for execution from source root
+    from prompt_failure import handle_failure, PromptBuildError  # type: ignore
 
-from .decorators import log_and_measure
-from .exceptions import MalformedPromptError, RateLimitError, VectorServiceError
-from .retriever import Retriever, PatchRetriever, FallbackResult
+try:  # pragma: no cover - prefer package relative import when available
+    from .decorators import log_and_measure  # type: ignore
+except Exception:  # pragma: no cover - fallback when executed from source root
+    from vector_service.decorators import log_and_measure  # type: ignore
+
+try:  # pragma: no cover - prefer package relative import when available
+    from .exceptions import (
+        MalformedPromptError,
+        RateLimitError,
+        VectorServiceError,
+    )
+except Exception:  # pragma: no cover - fallback when executed from source root
+    from vector_service.exceptions import (  # type: ignore
+        MalformedPromptError,
+        RateLimitError,
+        VectorServiceError,
+    )
+
+try:  # pragma: no cover - prefer package relative import when available
+    from .retriever import Retriever, PatchRetriever, FallbackResult  # type: ignore
+except Exception:  # pragma: no cover - fallback when executed from source root
+    from vector_service.retriever import (  # type: ignore
+        Retriever,
+        PatchRetriever,
+        FallbackResult,
+    )
 from config import ContextBuilderConfig
 from compliance.license_fingerprint import DENYLIST as _LICENSE_DENYLIST
-from .patch_logger import _VECTOR_RISK  # type: ignore
+try:  # pragma: no cover - prefer package relative import when available
+    from .patch_logger import _VECTOR_RISK  # type: ignore
+except Exception:  # pragma: no cover - fallback when executed from source root
+    from vector_service.patch_logger import _VECTOR_RISK  # type: ignore
 from patch_safety import PatchSafety
-from .ranking_utils import rank_patches
-from .embedding_backfill import (
-    ensure_embeddings_fresh,
-    StaleEmbeddingsError,
-    EmbeddingBackfill,
-    schedule_backfill,
-)
+try:  # pragma: no cover - prefer package relative import when available
+    from .ranking_utils import rank_patches  # type: ignore
+except Exception:  # pragma: no cover - fallback when executed from source root
+    from vector_service.ranking_utils import rank_patches  # type: ignore
+
+try:  # pragma: no cover - prefer package relative import when available
+    from .embedding_backfill import (  # type: ignore
+        ensure_embeddings_fresh,
+        StaleEmbeddingsError,
+        EmbeddingBackfill,
+        schedule_backfill,
+    )
+except Exception:  # pragma: no cover - fallback when executed from source root
+    from vector_service.embedding_backfill import (  # type: ignore
+        ensure_embeddings_fresh,
+        StaleEmbeddingsError,
+        EmbeddingBackfill,
+        schedule_backfill,
+    )
 from prompt_types import Prompt
 
 try:  # pragma: no cover - optional precise tokenizer
@@ -234,10 +275,13 @@ def _ensure_vector_service() -> None:
 try:  # pragma: no cover - optional dependency
     from . import ErrorResult  # type: ignore
 except Exception:  # pragma: no cover - fallback when undefined
-    class ErrorResult(Exception):
-        """Fallback ErrorResult used when vector service lacks explicit class."""
+    try:  # pragma: no cover - fallback to package import when available
+        from vector_service import ErrorResult  # type: ignore
+    except Exception:  # pragma: no cover - final fallback when unavailable
+        class ErrorResult(Exception):
+            """Fallback ErrorResult used when vector service lacks explicit class."""
 
-        pass
+            pass
 
 try:  # pragma: no cover - heavy dependency
     from menace_memory_manager import MenaceMemoryManager
@@ -333,8 +377,11 @@ class ContextBuilder:
 
                 try:  # package relative import when available
                     from .. import retrieval_ranker as _rr  # type: ignore
-                except Exception:  # pragma: no cover - fallback
-                    import retrieval_ranker as _rr  # type: ignore
+                except Exception:  # pragma: no cover - fallback when layout differs
+                    try:
+                        from menace import retrieval_ranker as _rr  # type: ignore
+                    except Exception:  # pragma: no cover - fallback to repo root
+                        import retrieval_ranker as _rr  # type: ignore
 
                 cfg = Path("retrieval_ranker.json")
                 model_path = cfg

--- a/vector_service/context_builder.py
+++ b/vector_service/context_builder.py
@@ -1,36 +1,66 @@
-"""Shared helpers for consistent ContextBuilder error handling."""
+"""Compatibility layer exposing the canonical :mod:`ContextBuilder` API.
+
+Historically the real implementation lived in :mod:`vector_service`.  The
+project was later refactored so the heavy ``ContextBuilder`` implementation sits
+at the repository root (and is also vendored under ``menace`` for package
+installs), while this module only provided minimal error helpers.  Some callers
+– like the sandbox bootstrap script in this kata – still import
+``ContextBuilder`` from :mod:`vector_service.context_builder`.  Importing the
+module therefore raised ``ImportError`` because the class was no longer exposed
+here.
+
+To retain backwards compatibility we now proxy the public surface of the real
+builder and error helpers.  This keeps import paths stable without duplicating
+logic.
+"""
 
 from __future__ import annotations
 
-from typing import NoReturn
-import logging
+# ``PromptBuildError`` and ``handle_failure`` live in ``prompt_failure``.  We try
+# the package-relative import first to support ``menace.*`` consumers and fall
+# back to the repository root module for direct execution from source.
+try:  # pragma: no cover - optional when package layout differs
+    from menace.prompt_failure import (  # type: ignore
+        PromptBuildError as _PromptBuildError,
+        handle_failure as _handle_failure,
+    )
+except ImportError:  # pragma: no cover - fallback during local execution
+    from prompt_failure import (  # type: ignore
+        PromptBuildError as _PromptBuildError,
+        handle_failure as _handle_failure,
+    )
+
+# Re-export ``ContextBuilder`` and related helpers from their canonical module.
+# The implementation lives at the repository root but is also mirrored under the
+# ``menace`` namespace when installed as a package.
+try:  # pragma: no cover - optional when executed from installed package
+    from menace.context_builder import (  # type: ignore
+        ContextBuilder,
+        build_prompt,
+        load_failed_tags,
+        record_failed_tags,
+    )
+except ImportError:  # pragma: no cover - fallback when running from source
+    from context_builder import (  # type: ignore
+        ContextBuilder,
+        build_prompt,
+        load_failed_tags,
+        record_failed_tags,
+    )
 
 
-class PromptBuildError(RuntimeError):
-    """Raised when prompt construction via ``ContextBuilder`` fails."""
+PromptBuildError = _PromptBuildError
+handle_failure = _handle_failure
 
+# ``__all__`` explicitly lists the symbols re-exported for consumers relying on
+# ``from vector_service.context_builder import …`` semantics.
+__all__ = [
+    "ContextBuilder",
+    "PromptBuildError",
+    "handle_failure",
+    "build_prompt",
+    "load_failed_tags",
+    "record_failed_tags",
+]
 
-def handle_failure(
-    message: str, exc: BaseException, *, logger: logging.Logger | None = None
-) -> NoReturn:
-    """Log ``message`` and raise :class:`PromptBuildError` chained from ``exc``.
-
-    Parameters
-    ----------
-    message:
-        Human readable description of the failure.
-    exc:
-        The exception raised while attempting to build a prompt.
-    logger:
-        Optional logger used for the error message.  When omitted a module level
-        logger tied to ``context_builder`` is used so that callers without a
-        bespoke logger still emit diagnostics.
-    """
-
-    log = logger or logging.getLogger(__name__)
-    log.exception(message)
-    raise PromptBuildError(message) from exc
-
-
-__all__ = ["PromptBuildError", "handle_failure"]
 


### PR DESCRIPTION
## Summary
- expose the canonical ContextBuilder implementation and helpers from vector_service.context_builder so legacy imports continue to work
- make the repository-root ContextBuilder module resilient to being imported outside the package layout by adding fallbacks for its internal dependencies

## Testing
- python manual_bootstrap.py *(fails: FileNotFoundError: 'menace_retrieval_cache_local.db' not found under /workspace/menace-self-coding)*

------
https://chatgpt.com/codex/tasks/task_e_68ce3281c8a0832e9e9f97f8636153a2